### PR TITLE
* GH actions: fixed Release workflow; misc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # Use the npm token stored in GitHub secrets
         run: echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
 
-      - name: Install Dependencies
-        run: npm publish --access public
+      - name: Build sources
+        run: npm run build
+        
+      - name: Publish to registry
+        run: npm publish
         

--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ tuyacli test
   - [x] control a device's state
   - [x] control a device's custom attributes
 - [x] use [Configstore](https://www.npmjs.com/package/configstore) for credentials & device cache _(not `session.json`)_
+  - [ ] encrypt credentials at rest 
 - [x] implement unit tests
+- [x] add support for CommonJS
 - [ ] document code & generate JSDoc
 - [ ] dockerize
 - [ ] implement classes for other IoT devices (climate, fan, lock, etc.)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuya-smartlife-api",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Library/CLI interface for Tuya IoT devices through the Smart Life API",
   "bin": {
     "tuyacli": "./dist/cjs/cli.js"


### PR DESCRIPTION
+ GH actions: added missing crucial building step for artifacts
- GH actions: release: removed `--access public` from `npm publish` - it overwrites package metadata and previous versions are lost :/ 
- ! bumped minor version for re-publish to NPM
* README.md: updated Roadmap