### PR TITLE
Bugfixes on cli auth, light control & session storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuya-smartlife-api",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Library/CLI interface for Tuya IoT devices through the Smart Life API",
   "bin": {
     "tuyacli": "./dist/cjs/cli.js"

--- a/src/cli.js
+++ b/src/cli.js
@@ -79,6 +79,7 @@ async function init() {
 }
 
 function finish() {
+	debug(`Finished, storing session`);
 	try {
 		sessionStore.set('session', client.session);
     } catch (e) {
@@ -371,11 +372,10 @@ program
 				debug(`Invoking setColor on ${dev.objName} with RGB: ${JSON.stringify({ red, green, blue })}`);
 				await dev.setColorRGB({ red, green, blue });
 			}
-
-			return dev;
+			return Promise.resolve(dev);
 		}));
-
-		await finish()
+		
+		await finish();
 	});
 
 // Get help

--- a/src/cli.js
+++ b/src/cli.js
@@ -48,9 +48,7 @@ async function auth() {
             ],
             default: TuyaDefaults.REGION, 
         }).catch(cbInterrupt);
-	config['HA_CC'] = await input({ message: 'Contry code', required: true, default: TuyaDefaults.COUNTRYCODES[config['HA_REGION']] }).catch(cbInterrupt),
-
-	authConfigStore.set('auth', config);
+	config['HA_CC'] = await input({ message: 'Contry code', required: true, default: TuyaDefaults.COUNTRYCODES[config['HA_REGION']] }).catch(cbInterrupt);
 
 	try {
 		await client.init(config.HA_EMAIL, config.HA_PASS, config.HA_REGION, config.HA_CC);
@@ -59,6 +57,7 @@ async function auth() {
         process.exit(1);
 	}
 	
+	authConfigStore.set('auth', config);
 	authConfigStore.set('lastLogin', Math.floor(Date.now()/1000));
 }
 
@@ -337,9 +336,9 @@ program
 		};
 		let tDevices = client.getAllDevices();
 		tDevices = await Promise.all(tDevices.filter((dev) => (~dev.objName.toLowerCase().indexOf(device.toLowerCase()) || dev.objId == device)).map(async (dev) => {			
-			if (!dev.data.online) 
+			if (!dev.data.online)
 				return;
-
+			
 			if (opts.state) {
 				if (!Object.keys(actionMethods).includes(opts.state)) {
 					console.error('Error: Invalid options format? Use DEBUG=cli');

--- a/src/cli.js
+++ b/src/cli.js
@@ -336,9 +336,12 @@ program
 		};
 		let tDevices = client.getAllDevices();
 		tDevices = await Promise.all(tDevices.filter((dev) => (~dev.objName.toLowerCase().indexOf(device.toLowerCase()) || dev.objId == device)).map(async (dev) => {			
-			if (!dev.data.online)
+			// Known issue: device status is propagated once every N minutes
+			// so that shouldn't stop us from trying
+			if (0 && !dev.data.online) {
 				return;
-			
+			}
+
 			if (opts.state) {
 				if (!Object.keys(actionMethods).includes(opts.state)) {
 					console.error('Error: Invalid options format? Use DEBUG=cli');

--- a/src/cli.js
+++ b/src/cli.js
@@ -222,6 +222,10 @@ program
 				await tBulb.turnOn();
 				await sleep(500);
 		
+				log('Test Light Bulb color brightness...');
+				await tBulb.setBrightness(50);
+				await sleep(500);
+
 				log('Test Light Bulb color temperatures...');
 				await tBulb.setColorTemp(1000);
 				await sleep(500);
@@ -353,7 +357,7 @@ program
 				debug(`Invoking toggle on ${dev.objName}`);
 				await dev.toggle();
 			} else if (opts.brightness) {
-				debug(`Invoking setBrightnes on ${dev.objName}`);
+				debug(`Invoking setBrightness on ${dev.objName}`);
 				await dev.setBrightness(opts.brightness);
 			} else if (opts.temperature) {
 				debug(`Invoking setColorTemp on ${dev.objName}`);

--- a/src/devices/light.mjs
+++ b/src/devices/light.mjs
@@ -45,16 +45,6 @@ export class TuyaLight extends TuyaDevice {
       return parseInt(this.data.brightness);
     }
   }
-
-  _setBrightness(brightness) {
-    const workMode = this.data.color_mode;
-    if (workMode === 'colour' && this.data.color) {
-      this.data.color.brightness = brightness;
-    } else {
-      this.data.brightness = brightness;
-    }
-  }
-
   
   supportColor() {
     return !!this.data.color;

--- a/src/devices/light.mjs
+++ b/src/devices/light.mjs
@@ -40,15 +40,15 @@ export class TuyaLight extends TuyaDevice {
     const workMode = this.data.color_mode;
     if (workMode === 'colour' && this.data.color) {
       const color = this.data.color;
-      return Math.round((color.brightness * 255) / 100);
+      return Math.round((parseInt(color.brightness) * 255) / 100);
     } else {
-      return this.data.brightness;
+      return parseInt(this.data.brightness);
     }
   }
 
   _setBrightness(brightness) {
     const workMode = this.data.color_mode;
-    if (workMode === 'colour') {
+    if (workMode === 'colour' && this.data.color) {
       this.data.color.brightness = brightness;
     } else {
       this.data.brightness = brightness;
@@ -82,7 +82,7 @@ export class TuyaLight extends TuyaDevice {
   }
 
   async setBrightness(brightness) {
-    const value = Math.round((brightness * 100) / 255);
+    const value = parseInt(brightness)
     let res = this.api.deviceControl(this.objectId(), 'brightnessSet', { value });
     if (res[0]) {
       this.data.brightness = value;

--- a/src/devices/light.mjs
+++ b/src/devices/light.mjs
@@ -82,13 +82,24 @@ export class TuyaLight extends TuyaDevice {
   async setColor(hsbColor) {
     let res = await this.api.deviceControl(this.objectId(), 'colorSet', { color: hsbColor });
     if (res[0]) {
-      this.data.color = hsbColor;
+      this.data.color = hsbColor; // Legacy
+      
+      // Soft set, for actual device update is delayed
+      if (
+        hsbColor['hue'] == 0 
+        && hsbColor['saturation'] == 0 
+        &&  hsbColor['brightness'] == 100
+      ) {
+          this.data.color_mode = 'white'; 
+      } else {
+          this.data.color_mode = 'colour'; 
+      }
     }
   }
 
   async setColorRGB(rgbColor) {
     let hC = rgb2hsv([rgbColor.red, rgbColor.green, rgbColor.blue]);
-    this.setColor({ hue: hC['h'], saturation: hC['s'], brightness: hC['v'] });
+    await this.setColor({ hue: hC['h'], saturation: hC['s'], brightness: hC['v'] });
   }
 
   async setColorTemp(colorTemp) {
@@ -96,6 +107,7 @@ export class TuyaLight extends TuyaDevice {
       let res = await this.api.deviceControl(this.objectId(), 'colorTemperatureSet', { value: colorTemp });
       if (res[0]) {
         this.data.color_temp = colorTemp;
+        this.data.color_mode = 'white';  // Soft set 
       }
     } else {
       console.error('Color temp value out of range.')

--- a/src/devices/light.mjs
+++ b/src/devices/light.mjs
@@ -1,5 +1,9 @@
 import { TuyaDevice } from './base';
 
+
+const MIN_BRIGHTNESS = 0;
+const MAX_BRIGHTNESS = 100;
+
 const MIN_COLOR_TEMP = 1000;
 const MAX_COLOR_TEMP = 10000;
 
@@ -66,12 +70,16 @@ export class TuyaLight extends TuyaDevice {
 
   async setBrightness(brightness) {
     const value = parseInt(brightness);
-    let res = await this.api.deviceControl(this.objectId(), 'brightnessSet', { value });
-    if (res[0]) {
-      this.data.brightness = value;
+    if (value >= MIN_BRIGHTNESS && value <= MAX_BRIGHTNESS) {
+      const res = await this.api.deviceControl(this.objectId(), 'brightnessSet', { value });
+      if (res[0]) {
+        this.data.brightness = value;
+      } else {
+        console.error('could not set brightness');
+        console.debug(res[1]);
+      }
     } else {
-      console.error('could not set brightness');
-      console.debug(res[1]);
+      console.error(`Brightness value '${value}' out of range (${MIN_BRIGHTNESS} - ${MAX_BRIGHTNESS}).`);
     }
   }
 
@@ -102,17 +110,18 @@ export class TuyaLight extends TuyaDevice {
   }
 
   async setColorTemp(colorTemp) {
-    if (colorTemp >= MIN_COLOR_TEMP && colorTemp <= MAX_COLOR_TEMP) {
-      let res = await this.api.deviceControl(this.objectId(), 'colorTemperatureSet', { value: colorTemp });
+    const value = parseInt(colorTemp);
+    if (value >= MIN_COLOR_TEMP && value <= MAX_COLOR_TEMP) {
+      const res = await this.api.deviceControl(this.objectId(), 'colorTemperatureSet', { value });
       if (res[0]) {
-        this.data.color_temp = colorTemp;
+        this.data.color_temp = value;
         this.data.color_mode = 'white';  // Soft set 
       } else {
         console.error('could not set color temp');
         console.debug(res[1]);
       }
     } else {
-      console.error('Color temp value out of range.')
+      console.error(`Color temp value '${value}' out of range (${MIN_COLOR_TEMP} - ${MAX_COLOR_TEMP}).`);
     }
   }
 }

--- a/src/devices/light.mjs
+++ b/src/devices/light.mjs
@@ -37,8 +37,7 @@ export class TuyaLight extends TuyaDevice {
   }
 
   brightness() {
-    const workMode = this.data.color_mode;
-    if (workMode === 'colour' && this.data.color) {
+    if (this.data.color_mode === 'colour' && this.data.color) {
       const color = this.data.color;
       return Math.round((parseInt(color.brightness) * 255) / 100);
     } else {
@@ -56,8 +55,7 @@ export class TuyaLight extends TuyaDevice {
 
   hsColor() {
     if (this.data.color) {
-      const workMode = this.data.color_mode;
-      if (workMode === 'colour') {
+      if (this.data.color_mode === 'colour' && this.data.color) {
         const color = this.data.color;
         return [color.hue, color.saturation];
       } else {
@@ -72,10 +70,13 @@ export class TuyaLight extends TuyaDevice {
   }
 
   async setBrightness(brightness) {
-    const value = parseInt(brightness)
-    let res = this.api.deviceControl(this.objectId(), 'brightnessSet', { value });
+    const value = parseInt(brightness);
+    let res = await this.api.deviceControl(this.objectId(), 'brightnessSet', { value });
     if (res[0]) {
       this.data.brightness = value;
+    } else {
+      console.error('could not set brightness');
+      console.debug(res[1]);
     }
   }
 
@@ -94,6 +95,9 @@ export class TuyaLight extends TuyaDevice {
       } else {
           this.data.color_mode = 'colour'; 
       }
+    } else {
+      console.error('could not set color');
+      console.debug(res[1]);
     }
   }
 
@@ -108,6 +112,9 @@ export class TuyaLight extends TuyaDevice {
       if (res[0]) {
         this.data.color_temp = colorTemp;
         this.data.color_mode = 'white';  // Soft set 
+      } else {
+        console.error('could not set color temp');
+        console.debug(res[1]);
       }
     } else {
       console.error('Color temp value out of range.')

--- a/src/devices/light.mjs
+++ b/src/devices/light.mjs
@@ -57,11 +57,11 @@ export class TuyaLight extends TuyaDevice {
 
   
   supportColor() {
-    return this.data.color !== null;
+    return !!this.data.color;
   }
 
   supportColorTemp() {
-    return this.data.color_temp !== null;
+    return !!this.data.color_temp;
   }
 
   hsColor() {

--- a/src/devices/light.mjs
+++ b/src/devices/light.mjs
@@ -37,12 +37,7 @@ export class TuyaLight extends TuyaDevice {
   }
 
   brightness() {
-    if (this.data.color_mode === 'colour' && this.data.color) {
-      const color = this.data.color;
-      return Math.round((parseInt(color.brightness) * 255) / 100);
-    } else {
-      return parseInt(this.data.brightness);
-    }
+    return parseInt(this.data.brightness);
   }
   
   supportColor() {


### PR DESCRIPTION
* store credentials only after successful authentication
* bypass device online check on `control`
* light: fixed brightness faulty calculation logic 
* light: fix faulty `supportColor()` &   `supportColorTemp()` checks
* test `light.setBrightness()`
* light: dropped legacy `_setBrightness()`
* bugfix: properly store session after control action
* light: store `colour_mode` based on set color
* light: store `brightness` on control; extensive error checking on control; misc cleanup
* light: valudate brightness value on control (same as color temp); misc cleanup
* ^ 0.8.4